### PR TITLE
Improve route transitions

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
   fastRefresh: true,
   onDemandEntries: {
     maxInactiveAge: 15 * 60 * 1000,
-    pageBufferLenth: 4
+    pagesBufferLength: 4,
   },
   concurrentFeatures: true,
   swcMinify: true,

--- a/src/components/sidebar/menu-options.tsx
+++ b/src/components/sidebar/menu-options.tsx
@@ -34,6 +34,7 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipProvider, TooltipTrigger } from '@radix-ui/react-tooltip'
 import { TooltipContent } from '../ui/tooltip'
+import { useRouter } from 'next/navigation'
 
 type Props = {
   defaultOpen?: boolean
@@ -56,6 +57,7 @@ const MenuOptions = ({
 }: Props) => {
   const { setOpen } = useModal()
   const [isMounted, setIsMounted] = useState(false)
+  const router = useRouter()
 
   const openState = useMemo(
     () => (defaultOpen ? { open: true } : {}),
@@ -65,6 +67,15 @@ const MenuOptions = ({
   useEffect(() => {
     setIsMounted(true)
   }, [])
+
+  useEffect(() => {
+    const routes: string[] = []
+    if (user?.Agency?.id) {
+      routes.push(`/agency/${user.Agency.id}`)
+    }
+    subAccounts.forEach((sa) => routes.push(`/subaccount/${sa.id}`))
+    routes.forEach((r) => router.prefetch(r))
+  }, [router, user?.Agency?.id, subAccounts])
 
   if (!isMounted) return
 


### PR DESCRIPTION
## Summary
- fix onDemandEntries option name in `next.config.js`
- prefetch sidebar routes for faster navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d43e8b9908333bc8d34a8226633c0